### PR TITLE
Add forex api currencybeacon latest and historical

### DIFF
--- a/pfm-core/src/forex/currency_test.rs
+++ b/pfm-core/src/forex/currency_test.rs
@@ -9,7 +9,7 @@ use crate::forex::{Currency, Money};
 #[test]
 fn test_currency_items() {
     let currency_variants_count = Currency::iter().count();
-    let expected_count = 30;
+    let expected_count = 28;
     assert_eq!(currency_variants_count, expected_count);
 }
 

--- a/pfm-core/src/forex/entity_test.rs
+++ b/pfm-core/src/forex/entity_test.rs
@@ -1,0 +1,86 @@
+use strum::IntoEnumIterator;
+
+use super::{entity::RatesData, Currency, Money};
+
+#[test]
+fn test_rates_data_fields() {
+    let rates_data = RatesData {
+        ..Default::default()
+    };
+
+    let ret = match rates_data {
+        RatesData {
+            usd,
+            cad,
+            eur,
+            gbp,
+            chf,
+            rub,
+            cny,
+            jpy,
+            krw,
+            hkd,
+            idr,
+            myr,
+            sgd,
+            thb,
+            sar,
+            aed,
+            kwd,
+            inr,
+            aud,
+            nzd,
+            xau,
+            xag,
+            xpt,
+            btc,
+            eth,
+            sol,
+            xrp,
+            ada,
+        } => vec![
+            Money::USD(usd),
+            Money::CAD(cad),
+            Money::EUR(eur),
+            Money::GBP(gbp),
+            Money::CHF(chf),
+            Money::RUB(rub),
+            Money::CNY(cny),
+            Money::JPY(jpy),
+            Money::KRW(krw),
+            Money::HKD(hkd),
+            Money::IDR(idr),
+            Money::MYR(myr),
+            Money::SGD(sgd),
+            Money::THB(thb),
+            Money::SAR(sar),
+            Money::AED(aed),
+            Money::KWD(kwd),
+            Money::INR(inr),
+            Money::AUD(aud),
+            Money::NZD(nzd),
+            Money::XAU(xau),
+            Money::XAG(xag),
+            Money::XPT(xpt),
+            Money::BTC(btc),
+            Money::ETH(eth),
+            Money::SOL(sol),
+            Money::XRP(xrp),
+            Money::ADA(ada),
+        ],
+    };
+
+    let money_variants_count = Money::iter().count();
+    let currency_variants_count = Currency::iter().count();
+
+    println!(
+        "Money variants: {}, \nCurrency variants: {}, \nret count: {}",
+        money_variants_count,
+        currency_variants_count,
+        ret.len()
+    );
+
+    assert_eq!(ret.len(), money_variants_count);
+    assert_eq!(ret.len(), currency_variants_count);
+    assert_eq!(money_variants_count, currency_variants_count);
+}

--- a/pfm-core/src/forex/mod.rs
+++ b/pfm-core/src/forex/mod.rs
@@ -4,6 +4,8 @@ pub use currency::Currency;
 mod currency_test;
 
 pub mod entity;
+#[cfg(test)]
+mod entity_test;
 
 pub mod interface;
 pub use interface::{ForexError, ForexResult};

--- a/pfm-core/src/forex/money_test.rs
+++ b/pfm-core/src/forex/money_test.rs
@@ -6,7 +6,7 @@ use super::money::MONEY_FORMAT_REGEX;
 #[test]
 fn test_money_items() {
     let money_variants_count = Money::iter().count();
-    let expected_count = 30;
+    let expected_count = 28;
     assert_eq!(money_variants_count, expected_count);
 }
 

--- a/pfm-core/src/forex_impl/currencybeacon.rs
+++ b/pfm-core/src/forex_impl/currencybeacon.rs
@@ -1,0 +1,315 @@
+use std::str::FromStr;
+
+use anyhow::{anyhow, Context};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use crate::{
+    forex::{
+        entity::{HistoricalRates, Rates, RatesData, RatesResponse},
+        interface::{AsInternalError, ForexHistoricalRates, ForexRates},
+        Currency, ForexError, ForexResult,
+    },
+    global,
+};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+/**
+https://currencybeacon.com
+5,000 API Requests
+Hourly updates
+Latest Rates
+Historical Rates
+Rate limit: // TODO ask currencybeacon for rate limit
+"End-of-day rates are available historically for all days going back to 1st January, 1996."
+*/
+
+const LATEST_ENDPOINT: &str = "https://api.currencybeacon.com/v1/latest";
+const HISTORICAL_ENDPOINT: &str = "https://api.currencybeacon.com/v1/historical";
+const SOURCE: &str = "currencybeacon.com";
+const END_OF_DAY_HOUR: &str = "T23:59:59Z";
+
+#[derive(Clone)]
+pub struct Api {
+    key: &'static str,
+    client: reqwest::Client,
+}
+
+impl Api {
+    pub fn new(key: &'static str, http_client: reqwest::Client) -> Self {
+        Self {
+            key,
+            client: http_client,
+        }
+    }
+}
+
+impl TryFrom<Response> for RatesResponse<Rates> {
+    type Error = ForexError;
+
+    fn try_from(value: Response) -> Result<Self, Self::Error> {
+        let date = value
+            .response
+            .date
+            .parse::<DateTime<Utc>>()
+            .context("currencybeacon parse latest rates datetime")
+            .as_internal_err()?;
+
+        let base = Currency::from_str(&value.response.base.as_str())
+            .context("currencybeacon parse base currency")
+            .as_internal_err()?;
+
+        let rates = Rates {
+            latest_update: date,
+            base,
+            rates: RatesData {
+                usd: value.response.rates.usd.unwrap_or_default(),
+                cad: value.response.rates.cad.unwrap_or_default(),
+                eur: value.response.rates.eur.unwrap_or_default(),
+                gbp: value.response.rates.gbp.unwrap_or_default(),
+                chf: value.response.rates.chf.unwrap_or_default(),
+                rub: value.response.rates.rub.unwrap_or_default(),
+                cny: value.response.rates.cny.unwrap_or_default(),
+                jpy: value.response.rates.jpy.unwrap_or_default(),
+                krw: value.response.rates.krw.unwrap_or_default(),
+                hkd: value.response.rates.hkd.unwrap_or_default(),
+                idr: value.response.rates.idr.unwrap_or_default(),
+                myr: value.response.rates.myr.unwrap_or_default(),
+                sgd: value.response.rates.sgd.unwrap_or_default(),
+                thb: value.response.rates.thb.unwrap_or_default(),
+                sar: value.response.rates.sar.unwrap_or_default(),
+                aed: value.response.rates.aed.unwrap_or_default(),
+                kwd: value.response.rates.kwd.unwrap_or_default(),
+                inr: value.response.rates.inr.unwrap_or_default(),
+                aud: value.response.rates.aud.unwrap_or_default(),
+                nzd: value.response.rates.nzd.unwrap_or_default(),
+                xau: value.response.rates.xau.unwrap_or_default(),
+                xag: value.response.rates.xag.unwrap_or_default(),
+                xpt: value.response.rates.xpt.unwrap_or_default(),
+                btc: value.response.rates.btc.unwrap_or_default(),
+                eth: value.response.rates.eth.unwrap_or_default(),
+                sol: value.response.rates.sol.unwrap_or_default(),
+                xrp: value.response.rates.xrp.unwrap_or_default(),
+                ada: value.response.rates.ada.unwrap_or_default(),
+            },
+        };
+
+        Ok(RatesResponse::new(SOURCE.into(), rates))
+    }
+}
+
+impl TryFrom<Response> for RatesResponse<HistoricalRates> {
+    type Error = ForexError;
+
+    fn try_from(value: Response) -> Result<Self, Self::Error> {
+        let date_time_str = format!("{}{}", value.response.date, END_OF_DAY_HOUR);
+        let date = date_time_str
+            .parse::<DateTime<Utc>>()
+            .context("currencybeacon parse historical rates datetime")
+            .as_internal_err()?;
+
+        let base = Currency::from_str(&value.response.base.as_str())
+            .context("currencybeacon parse base currency")
+            .as_internal_err()?;
+
+        let historical_rates = HistoricalRates {
+            date,
+            base,
+            rates: RatesData {
+                usd: value.response.rates.usd.unwrap_or_default(),
+                cad: value.response.rates.cad.unwrap_or_default(),
+                eur: value.response.rates.eur.unwrap_or_default(),
+                gbp: value.response.rates.gbp.unwrap_or_default(),
+                chf: value.response.rates.chf.unwrap_or_default(),
+                rub: value.response.rates.rub.unwrap_or_default(),
+                cny: value.response.rates.cny.unwrap_or_default(),
+                jpy: value.response.rates.jpy.unwrap_or_default(),
+                krw: value.response.rates.krw.unwrap_or_default(),
+                hkd: value.response.rates.hkd.unwrap_or_default(),
+                idr: value.response.rates.idr.unwrap_or_default(),
+                myr: value.response.rates.myr.unwrap_or_default(),
+                sgd: value.response.rates.sgd.unwrap_or_default(),
+                thb: value.response.rates.thb.unwrap_or_default(),
+                sar: value.response.rates.sar.unwrap_or_default(),
+                aed: value.response.rates.aed.unwrap_or_default(),
+                kwd: value.response.rates.kwd.unwrap_or_default(),
+                inr: value.response.rates.inr.unwrap_or_default(),
+                aud: value.response.rates.aud.unwrap_or_default(),
+                nzd: value.response.rates.nzd.unwrap_or_default(),
+                xau: value.response.rates.xau.unwrap_or_default(),
+                xag: value.response.rates.xag.unwrap_or_default(),
+                xpt: value.response.rates.xpt.unwrap_or_default(),
+                btc: value.response.rates.btc.unwrap_or_default(),
+                eth: value.response.rates.eth.unwrap_or_default(),
+                sol: value.response.rates.sol.unwrap_or_default(),
+                xrp: value.response.rates.xrp.unwrap_or_default(),
+                ada: value.response.rates.ada.unwrap_or_default(),
+            },
+        };
+
+        Ok(RatesResponse::new(SOURCE.into(), historical_rates))
+    }
+}
+
+// --- latest and historical rates response
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Response {
+    pub meta: Meta,
+    pub response: ResponseData,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Meta {
+    pub code: u16,
+    pub disclaimer: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResponseData {
+    pub date: String,
+    pub base: String,
+    pub rates: ResponseRates,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResponseRates {
+    #[serde(rename = "USD", default)]
+    pub usd: Option<Decimal>,
+    #[serde(rename = "CAD", default)]
+    pub cad: Option<Decimal>,
+    #[serde(rename = "EUR", default)]
+    pub eur: Option<Decimal>,
+    #[serde(rename = "GBP", default)]
+    pub gbp: Option<Decimal>,
+    #[serde(rename = "CHF", default)]
+    pub chf: Option<Decimal>,
+    #[serde(rename = "RUB", default)]
+    pub rub: Option<Decimal>,
+    #[serde(rename = "CNY", default)]
+    pub cny: Option<Decimal>,
+    #[serde(rename = "JPY", default)]
+    pub jpy: Option<Decimal>,
+    #[serde(rename = "KRW", default)]
+    pub krw: Option<Decimal>,
+    #[serde(rename = "HKD", default)]
+    pub hkd: Option<Decimal>,
+    #[serde(rename = "IDR", default)]
+    pub idr: Option<Decimal>,
+    #[serde(rename = "MYR", default)]
+    pub myr: Option<Decimal>,
+    #[serde(rename = "SGD", default)]
+    pub sgd: Option<Decimal>,
+    #[serde(rename = "THB", default)]
+    pub thb: Option<Decimal>,
+    #[serde(rename = "SAR", default)]
+    pub sar: Option<Decimal>,
+    #[serde(rename = "AED", default)]
+    pub aed: Option<Decimal>,
+    #[serde(rename = "KWD", default)]
+    pub kwd: Option<Decimal>,
+    #[serde(rename = "INR", default)]
+    pub inr: Option<Decimal>,
+    #[serde(rename = "AUD", default)]
+    pub aud: Option<Decimal>,
+    #[serde(rename = "NZD", default)]
+    pub nzd: Option<Decimal>,
+    #[serde(rename = "XAU", default)]
+    pub xau: Option<Decimal>,
+    #[serde(rename = "XAG", default)]
+    pub xag: Option<Decimal>,
+    #[serde(rename = "XPT", default)]
+    pub xpt: Option<Decimal>,
+    #[serde(rename = "BTC", default)]
+    pub btc: Option<Decimal>,
+    #[serde(rename = "ETH", default)]
+    pub eth: Option<Decimal>,
+    #[serde(rename = "SOL", default)]
+    pub sol: Option<Decimal>,
+    #[serde(rename = "XRP", default)]
+    pub xrp: Option<Decimal>,
+    #[serde(rename = "ADA", default)]
+    pub ada: Option<Decimal>,
+}
+
+// --- END
+
+#[async_trait]
+impl ForexRates for Api {
+    async fn rates(&self, base: Currency) -> ForexResult<RatesResponse<Rates>> {
+        let symbols = Currency::to_comma_separated_list_str();
+        let params = [
+            ("api_key", self.key),
+            ("base", base.code()),
+            ("symbols", symbols.as_str()),
+        ];
+
+        let ret_str = self
+            .client
+            .get(LATEST_ENDPOINT)
+            .query(&params)
+            .send()
+            .await
+            .context("currencybeacon invoking latest api")
+            .as_internal_err()?
+            .text()
+            .await
+            .context("currencybeacon fetching latest resp in text")
+            .as_internal_err()?;
+
+        let resp = serde_json::from_str::<Response>(&ret_str)
+            .map_err(|err| {
+                anyhow!(
+                    "currencybeacon failed parsing latest into JSON: {}, {}",
+                    &ret_str,
+                    err
+                )
+            })
+            .as_internal_err()?;
+
+        Ok(resp.try_into()?)
+    }
+}
+
+#[async_trait]
+impl ForexHistoricalRates for Api {
+    async fn historical_rates(
+        &self,
+        date: DateTime<Utc>,
+        base: Currency,
+    ) -> ForexResult<RatesResponse<HistoricalRates>> {
+        let symbols = Currency::to_comma_separated_list_str();
+        let yyyymmdd = date.format("%Y-%m-%d").to_string();
+        let params = [
+            ("api_key", self.key),
+            ("base", base.code()),
+            ("date", yyyymmdd.as_str()),
+            ("symbols", symbols.as_str()),
+        ];
+
+        let ret_str = self
+            .client
+            .get(HISTORICAL_ENDPOINT)
+            .query(&params)
+            .send()
+            .await
+            .context("currencybeacon invoking historical api")
+            .as_internal_err()?
+            .text()
+            .await
+            .context("currencybeacon fetching historical resp in text")
+            .as_internal_err()?;
+
+        let resp = serde_json::from_str::<Response>(&ret_str)
+            .map_err(|err| {
+                anyhow!(
+                    "currencybeacon failed parsing historical into JSON: {}, {}",
+                    &ret_str,
+                    err
+                )
+            })
+            .as_internal_err()?;
+
+        Ok(resp.try_into()?)
+    }
+}

--- a/pfm-core/src/forex_impl/mod.rs
+++ b/pfm-core/src/forex_impl/mod.rs
@@ -13,5 +13,8 @@ pub mod open_exchange_api;
 // #[cfg(test)]
 // mod open_exchange_api_test;
 
+/// https://currencybeacon.com/api-documentation
+pub mod currencybeacon;
+
 /// SERVER side storage for cron and http services
 pub mod forex_storage;

--- a/pfm-core/src/global.rs
+++ b/pfm-core/src/global.rs
@@ -252,6 +252,9 @@ pub struct Config {
     /// API key for https://openexchangerates.org
     #[serde(alias = "CORE_FOREX_OPEN_EXCHANGE_API_KEY")]
     pub forex_open_exchange_api_key: String,
+
+    #[serde(alias = "CORE_FOREX_CURRENCYBEACON")]
+    pub forex_currencybeacon_api_key: String,
 }
 
 #[cfg(test)]

--- a/pfm-core/tests/test_poll.rs
+++ b/pfm-core/tests/test_poll.rs
@@ -1,9 +1,17 @@
 use chrono::{TimeZone, Utc};
 use pfm_core::{
-    forex::service::{poll_historical_rates, poll_rates},
-    forex_impl::{self, forex_storage},
+    forex::{
+        interface::ForexStorage,
+        service::{poll_historical_rates, poll_rates},
+        Money,
+    },
+    forex_impl::{
+        self,
+        forex_storage::{self, ForexStorageImpl},
+    },
     global::{self, BASE_CURRENCY},
 };
+use rust_decimal_macros::dec;
 
 #[tokio::test]
 async fn test_exchange_api_latest() {
@@ -94,6 +102,37 @@ async fn test_open_exchange_rates_historical() {
     dbg!(&ret);
 
     assert!(ret.is_ok());
+
+    assert!(ret.as_ref().unwrap().error.is_none());
+}
+
+#[tokio::test]
+pub async fn test_currencybeacon_latest_rates() {
+    let api = forex_impl::currencybeacon::Api::new(
+        &global::config().forex_currencybeacon_api_key,
+        global::http_client(),
+    );
+    let storage = forex_storage::ForexStorageImpl::new(global::storage_fs());
+    let ret = poll_rates(&api, &storage, global::BASE_CURRENCY).await;
+    dbg!(&ret);
+
+    assert!(&ret.is_ok());
+
+    assert!(ret.as_ref().unwrap().error.is_none());
+}
+
+#[tokio::test]
+pub async fn test_currencybeacon_historical_rates() {
+    let api = forex_impl::currencybeacon::Api::new(
+        &global::config().forex_currencybeacon_api_key,
+        global::http_client(),
+    );
+    let storage = forex_storage::ForexStorageImpl::new(global::storage_fs());
+    let date = Utc.with_ymd_and_hms(2007, 6, 6, 0, 0, 0).unwrap();
+    let ret = poll_historical_rates(&api, &storage, date, global::BASE_CURRENCY).await;
+    dbg!(&ret);
+
+    assert!(&ret.is_ok());
 
     assert!(ret.as_ref().unwrap().error.is_none());
 }

--- a/pfm-core/tests/test_storage.rs
+++ b/pfm-core/tests/test_storage.rs
@@ -1,0 +1,31 @@
+use chrono::{TimeZone, Utc};
+use pfm_core::{
+    forex::{interface::ForexStorage, Money},
+    forex_impl::forex_storage::ForexStorageImpl,
+    global,
+};
+use rust_decimal_macros::dec;
+
+// test the forex storage impl on update historical
+// latest test: pass
+#[tokio::test]
+pub async fn test_storage_update_historical() {
+    dbg!("running test update historical");
+    println!("running test update historical");
+    let storage_impl = ForexStorageImpl::new(global::storage_fs());
+    let date = Utc.with_ymd_and_hms(2002, 2, 25, 0, 0, 0).unwrap();
+    let new_data = vec![
+        Money::XAU(dec!(0.04220322222)),
+        Money::XAG(dec!(0.23011116)),
+    ];
+    let before = ForexStorage::get_historical(&storage_impl, date)
+        .await
+        .unwrap();
+    dbg!(&before);
+    let after =
+        ForexStorage::update_historical_rates_data(&storage_impl, date, new_data.clone()).await;
+    dbg!(&after);
+
+    assert_eq!(after.as_ref().unwrap().data.rates.xau, new_data[0].amount());
+    assert_eq!(after.as_ref().unwrap().data.rates.xag, new_data[1].amount());
+}

--- a/pfm-tool/src/main.rs
+++ b/pfm-tool/src/main.rs
@@ -26,11 +26,12 @@ async fn main() {
     };
     println!("{}", start_date);
 
-    // let from = start_date;
-    let from = Utc.with_ymd_and_hms(2003, 9, 29, 0, 0, 0).unwrap();
+    let from = start_date;
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    // let from = Utc.with_ymd_and_hms(2003, 9, 29, 0, 0, 0).unwrap();
     let to = Utc.with_ymd_and_hms(2024, 12, 31, 0, 0, 0).unwrap();
     let storage = ForexStorageImpl::new(global::storage_fs());
-    let apiname = ApisName::CurrencyAPI;
+    let apiname = ApisName::OpenExchangeRatesAPI;
     let forex_api = select_api(apiname);
     let ret = fetch_historical_data(forex_api, storage, from, to).await;
     println!("{:?}", ret);
@@ -66,7 +67,7 @@ pub enum ApisName {
 
 #[derive(Clone)]
 pub enum Apis {
-    ExchangeAPI(ExchangeAPI), // rate limit 5 reqs/sec
+    ExchangeAPI(ExchangeAPI),
     CurrencyAPI(CurrencyAPI),
     OpenExchangeRatesAPI(OpenExchangeRatesAPI),
 }


### PR DESCRIPTION
- Test using pattern matching for entity RatesData to make sure it align with Money and Currency variants.