### PR TITLE
Currencybeacon: Add solana price from twelvedata

### DIFF
--- a/pfm-core/src/global.rs
+++ b/pfm-core/src/global.rs
@@ -262,6 +262,9 @@ pub struct Config {
 
     #[serde(alias = "CORE_FOREX_TRADERMADE_API_KEY")]
     pub forex_tradermade_api_key: String,
+
+    #[serde(alias = "CORE_FOREX_TWELVEDATA_API_KEY")]
+    pub forex_twelvedata_api_key: String,
 }
 
 #[cfg(test)]

--- a/pfm-core/tests/test_poll.rs
+++ b/pfm-core/tests/test_poll.rs
@@ -130,7 +130,7 @@ pub async fn test_currencybeacon_historical_rates() {
         global::http_client(),
     );
     let storage = forex_storage::ForexStorageImpl::new(global::storage_fs());
-    let date = Utc.with_ymd_and_hms(2007, 6, 6, 0, 0, 0).unwrap();
+    let date = Utc.with_ymd_and_hms(2022, 6, 6, 0, 0, 0).unwrap();
     let ret = poll_historical_rates(&api, &storage, date, global::BASE_CURRENCY).await;
     dbg!(&ret);
 


### PR DESCRIPTION
Currencybeacon doesn't provide Solana price, fetch from twelvedata instead.