### PR TITLE
Refactor error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,6 +1223,7 @@ dependencies = [
  "strum_macros",
  "thiserror 1.0.69",
  "tokio",
+ "uom",
  "uuid",
 ]
 
@@ -2273,6 +2274,16 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uom"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd36e5350a65d112584053ee91843955826bf9e56ec0d1351214e01f6d7cd9c"
+dependencies = [
+ "num-traits",
+ "typenum",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,5 @@ rusty-money = { version = "0.4", features = ["iso"] }
 
 # pfm-cron
 tokio-cron-scheduler = { version = "0.13", features = ["english", "signal"]}
+
+uom = "0.36"

--- a/pfm-core/Cargo.toml
+++ b/pfm-core/Cargo.toml
@@ -32,4 +32,4 @@ accounting = { workspace = true }
 iso_currency = { workspace = true }
 rusty-money = { workspace = true }
 
-
+uom = {workspace = true}

--- a/pfm-core/src/error.rs
+++ b/pfm-core/src/error.rs
@@ -1,0 +1,107 @@
+use thiserror::Error;
+
+/// Wrapper around anyhow::Error
+pub trait BaseError: Sized + std::error::Error + Send + Sync + 'static {
+    fn new(err: impl Into<anyhow::Error>) -> Self;
+
+    fn from_msg<S: AsRef<str>>(message: S) -> Self {
+        let err = anyhow::anyhow!("{}", message.as_ref());
+        Self::new(err)
+    }
+
+    fn from_err<E>(error: E) -> Self
+    where
+        E: Into<anyhow::Error> + std::error::Error + Send + Sync + 'static,
+    {
+        Self::new(error)
+    }
+
+    fn with_context<S: AsRef<str>>(
+        message: S,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        let err = anyhow::Error::new(source).context(message.as_ref().to_string());
+        Self::new(err)
+    }
+
+    fn cause(&self) -> String {
+        self.source()
+            .map(|err| err.to_string())
+            .unwrap_or("Error undefined".to_string())
+    }
+
+    fn detail(&self) -> String {
+        let error = self.to_string();
+        let cause = BaseError::cause(self);
+        format!("{} \nCaused by: {}", error, cause)
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Error: {0}")]
+pub struct Error(#[from] anyhow::Error);
+
+impl BaseError for Error {
+    fn new(err: impl Into<anyhow::Error>) -> Self {
+        Self(err.into())
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Client error: {0}")]
+pub struct ClientError(#[from] anyhow::Error);
+
+impl BaseError for ClientError {
+    fn new(err: impl Into<anyhow::Error>) -> Self {
+        Self(err.into())
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Internal error: {0}")]
+pub struct InternalError(#[from] anyhow::Error);
+
+impl BaseError for InternalError {
+    fn new(err: impl Into<anyhow::Error>) -> Self {
+        Self(err.into())
+    }
+}
+
+pub trait AsGenericError<T> {
+    fn as_generic_err(self) -> Result<T, Error>;
+}
+
+pub trait AsClientError<T> {
+    fn as_client_err(self) -> Result<T, ClientError>;
+}
+
+pub trait AsInternalError<T> {
+    fn as_internal_err(self) -> Result<T, InternalError>;
+}
+
+impl<T, E> AsGenericError<T> for Result<T, E>
+where
+    E: Into<anyhow::Error>,
+{
+    fn as_generic_err(self) -> Result<T, Error> {
+        self.map_err(|e| Error(e.into()))
+    }
+}
+
+impl<T, E> AsClientError<T> for Result<T, E>
+where
+    E: Into<anyhow::Error>,
+{
+    fn as_client_err(self) -> Result<T, ClientError> {
+        self.map_err(|e| ClientError(e.into()))
+    }
+}
+
+impl<T, E> AsInternalError<T> for Result<T, E>
+where
+    E: Into<anyhow::Error>,
+{
+    fn as_internal_err(self) -> Result<T, InternalError> {
+        self.map_err(|e| InternalError(e.into()))
+    }
+}

--- a/pfm-core/src/forex/currency.rs
+++ b/pfm-core/src/forex/currency.rs
@@ -5,10 +5,8 @@ use iso_currency::Currency as CurrencyLib;
 use serde::{Deserialize, Serialize};
 use strum::{EnumIter, IntoEnumIterator};
 
-use super::{
-    interface::{AsClientError, ForexError},
-    money::Money,
-};
+use super::{interface::ForexError, money::Money};
+use crate::error::AsClientError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, EnumIter)]
 pub enum Currency {

--- a/pfm-core/src/forex/entity.rs
+++ b/pfm-core/src/forex/entity.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use uuid::Uuid;
 
 use super::{currency::Currency, interface::ForexError, money::Money};
+use crate::error::BaseError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RatesResponse<T> {

--- a/pfm-core/src/forex/money.rs
+++ b/pfm-core/src/forex/money.rs
@@ -3,8 +3,9 @@ use std::{fmt::Display, str::FromStr};
 use super::{
     currency::Currency,
     entity::RatesData,
-    interface::{AsClientError, ForexError, ForexResult},
+    interface::{ForexError, ForexResult},
 };
+use crate::error::AsClientError;
 use accounting::Accounting;
 use anyhow::Context;
 use iso_currency::Currency as CurrencyLib;

--- a/pfm-core/src/forex_impl/currency_api.rs
+++ b/pfm-core/src/forex_impl/currency_api.rs
@@ -13,14 +13,14 @@ use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
+use crate::error::AsInternalError;
 use crate::forex::entity::RatesData;
-use crate::forex::interface::{AsInternalError, ForexHistoricalRates};
+use crate::forex::interface::ForexHistoricalRates;
 use crate::forex::ForexResult;
 use crate::forex::{
     entity::{HistoricalRates, RatesResponse},
     Currency, ForexError,
 };
-use crate::global;
 
 const SOURCE: &str = "currencyapi.com";
 

--- a/pfm-core/src/forex_impl/currencybeacon.rs
+++ b/pfm-core/src/forex_impl/currencybeacon.rs
@@ -2,16 +2,17 @@ use std::{collections::HashMap, str::FromStr};
 
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use rust_decimal_macros::dec;
 
+use crate::error::AsInternalError;
 use crate::{
     forex::{
         entity::{HistoricalRates, Rates, RatesData, RatesResponse},
-        interface::{AsInternalError, ForexHistoricalRates, ForexRates, ForexTimeseriesRates},
-        Currency, ForexError, ForexResult, Money,
+        interface::{ForexHistoricalRates, ForexRates, ForexTimeseriesRates},
+        Currency, ForexError, ForexResult,
     },
-    global::{self, constants::BASE_CURRENCY},
+    global::{self},
 };
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};

--- a/pfm-core/src/forex_impl/exchange_api.rs
+++ b/pfm-core/src/forex_impl/exchange_api.rs
@@ -10,9 +10,10 @@
 // - DAILY updates at 00.00 UTC, but slower to update on time.
 // - very limited historical rates.
 
+use crate::error::AsInternalError;
 use crate::forex::{
     entity::{HistoricalRates, RatesData, RatesResponse},
-    interface::{AsInternalError, ForexHistoricalRates, ForexRates},
+    interface::{ForexHistoricalRates, ForexRates},
     Currency, ForexError, ForexResult,
 };
 use anyhow::Context;

--- a/pfm-core/src/forex_impl/forex_storage.rs
+++ b/pfm-core/src/forex_impl/forex_storage.rs
@@ -6,9 +6,10 @@ use std::fmt::Debug;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
+use crate::error::AsInternalError;
 use crate::forex::entity::{HistoricalRates, Order, Rates, RatesList, RatesResponse};
-use crate::forex::interface::{AsInternalError, ForexStorage, ForexStorageDeletion};
-use crate::forex::{Currency, ForexResult};
+use crate::forex::interface::{ForexStorage, ForexStorageDeletion};
+use crate::forex::ForexResult;
 use crate::forex::{ForexError, Money};
 use crate::global::StorageFS;
 use anyhow::Context;

--- a/pfm-core/src/forex_impl/open_exchange_api.rs
+++ b/pfm-core/src/forex_impl/open_exchange_api.rs
@@ -10,9 +10,10 @@
 use anyhow::anyhow;
 use std::str::FromStr;
 
+use crate::error::AsInternalError;
 use crate::forex::{
     entity::{HistoricalRates, RatesData, RatesResponse},
-    interface::{AsInternalError, ForexHistoricalRates, ForexRates},
+    interface::{ForexHistoricalRates, ForexRates},
     Currency, ForexError, ForexResult,
 };
 use anyhow::Context;

--- a/pfm-core/src/forex_impl/tradermade.rs
+++ b/pfm-core/src/forex_impl/tradermade.rs
@@ -5,9 +5,10 @@ use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 
+use crate::error::AsInternalError;
 use crate::forex::{
     entity::{HistoricalRates, Rates, RatesData, RatesResponse},
-    interface::{AsInternalError, ForexHistoricalRates, ForexRates},
+    interface::{ForexHistoricalRates, ForexRates},
     Currency, ForexError, ForexResult,
 };
 

--- a/pfm-core/src/lib.rs
+++ b/pfm-core/src/lib.rs
@@ -1,5 +1,8 @@
+mod error;
 pub mod forex;
 pub mod forex_impl;
+
+pub mod pm;
 
 pub mod global;
 

--- a/pfm-http/src/dto.rs
+++ b/pfm-http/src/dto.rs
@@ -54,6 +54,9 @@ impl<T> HttpResponse<T> {
 
 #[derive(Debug, Error, Serialize)]
 pub enum AppError {
+    #[error("Not found: {0}")]
+    NoContent(String),
+
     #[error("Unauthorized: {0}")]
     Unauthorized(String),
 
@@ -67,6 +70,7 @@ pub enum AppError {
 impl IntoResponse for AppError {
     fn into_response(self) -> axum::response::Response {
         let (status_code, err_msg) = match self {
+            Self::NoContent(err) => (StatusCode::NO_CONTENT, err),
             Self::Unauthorized(err) => (StatusCode::UNAUTHORIZED, err),
             Self::BadRequest(err) => (StatusCode::BAD_REQUEST, err),
             Self::InternalServerError(err) => (StatusCode::INTERNAL_SERVER_ERROR, err),
@@ -81,6 +85,7 @@ impl IntoResponse for AppError {
 impl From<ForexError> for AppError {
     fn from(value: ForexError) -> Self {
         match value {
+            ForexError::Error(v) => Self::NoContent(v.to_string()),
             ForexError::ClientError(v) => Self::BadRequest(v.to_string()),
             ForexError::InternalError(v) => Self::InternalServerError(v.to_string()),
         }


### PR DESCRIPTION
- Make base error handling wrapping anyhow::Error.
- Other domain's errors use these base error types and traits.
- Add generic error Error.